### PR TITLE
Add GHA build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v3
+      - name: Set up msbuild
+        uses: microsoft/setup-msbuild@v2
+      - name: Set up nuget
+        uses: nuget/setup-nuget@v2
+        with:
+          nuget-version: '5.x'
+      - name: Run msbuild
+        run: msbuild trino-csharp/TrinoDriver.sln   


### PR DESCRIPTION
I am not an expert of this .net stuff .. just following what I find at https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-net and cobbling something together

Or maybe https://github.com/microsoft/setup-msbuild

Also have to figure out https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry and https://github.com/NuGet/setup-nuget


Still very much a work in progress

Do we have to merge this so it even runs in the first place? At this stage I am flying blind .. going to get back to this after some feedback and time to look into it more.

Probably also have to figure out how install this stuff locally... 