### PR TITLE
Fix error deserialization with non-empty suppressed filed

### DIFF
--- a/trino-csharp/Trino.Client/Model/StatementV1/TrinoErrorCause.cs
+++ b/trino-csharp/Trino.Client/Model/StatementV1/TrinoErrorCause.cs
@@ -30,7 +30,7 @@ namespace Trino.Client.Model.StatementV1
         /// <summary>
         /// Suppressed errors
         /// </summary>
-        public List<string> suppressed { get; set; }
+        public List<TrinoErrorCause> suppressed { get; set; }
 
         /// <summary>
         /// Cause of the error


### PR DESCRIPTION
The `suppressed` field should be of type `List<TrinoErrorCause>`, matching the definition in the Java version: [FailureInfo.java#L33](https://github.com/trinodb/trino/blob/7c63e8677f09db38a4a89c7ef4145d3a8b43a5d5/client/trino-client/src/main/java/io/trino/client/FailureInfo.java#L33)

Exception Message:
```
Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: {. Path 'error.failureInfo.suppressed', line 1, position 10820.
   at Newtonsoft.Json.JsonTextReader.ReadStringValue(ReadType readType)
   at Newtonsoft.Json.JsonTextReader.ReadAsString()
   at Newtonsoft.Json.JsonReader.ReadForType(JsonContract contract, Boolean hasConverter)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)

```