### PR TITLE
Fix HttpClient in StatementClientV1, fix unit test paths and add AssemblyInfo.cs

### DIFF
--- a/trino-csharp/Trino.Client.Test/StatementClientV1Tests.cs
+++ b/trino-csharp/Trino.Client.Test/StatementClientV1Tests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Trino.Client.Logging;
+
+namespace Trino.Client.Test
+{
+    [TestClass]
+    public class StatementClientV1Tests
+    {
+        [TestMethod]
+        public void StatementClientV1ShouldUseCorrectHttpClient()
+        {
+            // Arrange
+            var session = new ClientSession();
+            var cancellationToken = new CancellationToken();
+            ILoggerWrapper logger = null;
+
+            // Act
+            var statementClient = new StatementClientV1(session, cancellationToken, logger);
+
+            // Assert
+            var client = statementClient.httpClient;
+            var handler = client.GetType().BaseType.GetField("_handler", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(client) as HttpClientHandler;
+            Assert.IsNotNull(handler);
+            Assert.IsNotNull(handler.ServerCertificateCustomValidationCallback);
+        }
+    }
+}

--- a/trino-csharp/Trino.Client.Test/TrinoClientTests.cs
+++ b/trino-csharp/Trino.Client.Test/TrinoClientTests.cs
@@ -14,7 +14,7 @@ namespace Trino.Client.Test
         [TestMethod]
         public void TestTimestampConversion()
         {
-            using (TrinoTestServer server = TrinoTestServer.Create("trino_test_timestamp_conversion.txt"))
+            using (TrinoTestServer server = TrinoTestServer.Create("scripts\\trino_test_timestamp_conversion.txt"))
             {
                 TrinoConnectionProperties properties = server.GetConnectionProperties();
                 properties.Catalog = "tpch";
@@ -47,7 +47,7 @@ namespace Trino.Client.Test
         [TestMethod]
         public void TestReadZeroRows()
         {
-            using (TrinoTestServer server = TrinoTestServer.Create("zero_rows.txt"))
+            using (TrinoTestServer server = TrinoTestServer.Create("scripts\\zero_rows.txt"))
             {
                 TrinoConnectionProperties properties = server.GetConnectionProperties();
                 properties.Catalog = "tpch";
@@ -72,7 +72,7 @@ namespace Trino.Client.Test
         [TestMethod]
         public void TestCancellationGetSchema()
         {
-            using (TrinoTestServer server = TrinoTestServer.Create("trino_cancel.txt"))
+            using (TrinoTestServer server = TrinoTestServer.Create("scripts\\trino_cancel.txt"))
             {
                 TrinoConnectionProperties properties = server.GetConnectionProperties();
                 properties.Catalog = "tpch";
@@ -106,7 +106,7 @@ namespace Trino.Client.Test
         [TestMethod]
         public void TestTimeout()
         {
-            using (TrinoTestServer server = TrinoTestServer.Create("trino_client_timeout.txt", TimeSpan.FromSeconds(5)))
+            using (TrinoTestServer server = TrinoTestServer.Create("scripts\\trino_client_timeout.txt", TimeSpan.FromSeconds(5)))
             {
                 try
                 {
@@ -148,7 +148,7 @@ namespace Trino.Client.Test
         [TestMethod]
         public void TestParameters()
         {
-            using (TrinoTestServer server = TrinoTestServer.Create("parameters.txt"))
+            using (TrinoTestServer server = TrinoTestServer.Create("scripts\\parameters.txt"))
             {
                 TrinoConnectionProperties properties = server.GetConnectionProperties();
                 properties.Catalog = "delta";
@@ -193,7 +193,7 @@ namespace Trino.Client.Test
         [TestMethod]
         public void TrinoExceptionTest()
         {
-            using (TrinoTestServer server = TrinoTestServer.Create("trino_exception_test.txt"))
+            using (TrinoTestServer server = TrinoTestServer.Create("scripts\\trino_exception_test.txt"))
             {
                 TrinoConnectionProperties properties = server.GetConnectionProperties();
                 properties.SessionProperties = new Dictionary<string, string>() { { "query_cache_enabled", "false" } };
@@ -230,7 +230,7 @@ namespace Trino.Client.Test
         [TestMethod]
         public void TestGetSchema()
         {
-            using (TrinoTestServer server = TrinoTestServer.Create("trino_schema_columns.txt"))
+            using (TrinoTestServer server = TrinoTestServer.Create("scripts\\trino_schema_columns.txt"))
             {
                 TrinoConnectionProperties properties = server.GetConnectionProperties();
                 properties.Catalog = "delta";
@@ -269,7 +269,7 @@ namespace Trino.Client.Test
         [TestMethod]
         public void TrinoSessionTest()
         {
-            using (TrinoTestServer server = TrinoTestServer.Create("trino_session_test.txt"))
+            using (TrinoTestServer server = TrinoTestServer.Create("scripts\\trino_session_test.txt"))
             {
                 TrinoConnectionProperties properties = server.GetConnectionProperties();
                 properties.Catalog = "tpch";
@@ -308,7 +308,7 @@ namespace Trino.Client.Test
         [TestMethod]
         public void TestAllTypes()
         {
-            using (TrinoTestServer server = TrinoTestServer.Create("trino_all_types.txt"))
+            using (TrinoTestServer server = TrinoTestServer.Create("scripts\\trino_all_types.txt"))
             {
                 string all_types = $@"SELECT
                 CAST(NULL as varchar) AS null_varchar_column,

--- a/trino-csharp/Trino.Client/Properties/AssemblyInfo.cs
+++ b/trino-csharp/Trino.Client/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Trino.Client.Test")]

--- a/trino-csharp/Trino.Client/StatementClientV1.cs
+++ b/trino-csharp/Trino.Client/StatementClientV1.cs
@@ -146,7 +146,8 @@ namespace Trino.Client
                 return sslPolicyErrors == SslPolicyErrors.None;
             };
 
-            HttpClient httpClient = new HttpClient(handler);
+            //HttpClient httpClient = new HttpClient(handler);
+            this.httpClient = new HttpClient(handler);
             this.httpClient.Timeout = Constants.HttpConnectionTimeout;
 
             if (!this.Session.Properties.CompressionDisabled)

--- a/trino-csharp/Trino.Client/StatementClientV1.cs
+++ b/trino-csharp/Trino.Client/StatementClientV1.cs
@@ -146,7 +146,6 @@ namespace Trino.Client
                 return sslPolicyErrors == SslPolicyErrors.None;
             };
 
-            //HttpClient httpClient = new HttpClient(handler);
             this.httpClient = new HttpClient(handler);
             this.httpClient.Timeout = Constants.HttpConnectionTimeout;
 


### PR DESCRIPTION
The StatementClientV1 constructor previously created a new HttpClient instance, while the rest of the class used the HttpClient instance from the base class, AbstractClient<T>. This fix ensures that StatementClientV1 consistently uses the correct HttpClient.

 fix unit test paths and add AssemblyInfo.cs