### PR TITLE
TrinoFunction - new unit tests and some fixes for bugs using certain parameter types

### DIFF
--- a/trino-csharp/Trino.Client.Test/TrinoFunctionTests.cs
+++ b/trino-csharp/Trino.Client.Test/TrinoFunctionTests.cs
@@ -1,0 +1,112 @@
+﻿using Trino.Client.Utils;
+
+namespace Trino.Client.Test
+{
+    [TestClass]
+    public class TrinoFunctionTests
+    {
+        /// <summary>
+        /// We subclass the TrinoFunction class to easily access the output from BuildFunctionStatement()
+        /// </summary>
+        class TrinoFunctionTestHelper : TrinoFunction
+        {
+            public TrinoFunctionTestHelper(string catalog, string functionName, IList<object> parameters) : base(catalog, functionName, parameters)
+            {
+            }
+
+            public string GetStatement()
+            {
+                return base.BuildFunctionStatement();
+            }
+        }
+
+        [TestMethod]
+        public void TestNoParams()
+        {
+            var testTrinoFunction = new TrinoFunctionTestHelper("test", "testFunc", []);
+            var statement = testTrinoFunction.GetStatement();
+
+            Assert.AreEqual("test.testFunc()", statement);
+        }
+
+        [TestMethod]
+        public void TestOneStringParam()
+        {
+            var testTrinoFunction = new TrinoFunctionTestHelper("test", "testFunc", ["a"]);
+            var statement = testTrinoFunction.GetStatement();
+
+            Assert.AreEqual("test.testFunc('a')", statement);
+        }
+
+        [TestMethod]
+        public void TestTwoStringParams()
+        {
+            var testTrinoFunction = new TrinoFunctionTestHelper("test", "testFunc", ["a", "b"]);
+            var statement = testTrinoFunction.GetStatement();
+
+            Assert.AreEqual("test.testFunc('a', 'b')", statement);
+        }
+
+        [TestMethod]
+        public void TestNullCatalogue()
+        {
+            var testTrinoFunction = new TrinoFunctionTestHelper(null!, "testFunc", []);
+            var statement = testTrinoFunction.GetStatement();
+
+            Assert.AreEqual("testFunc()", statement);
+        }
+
+        [TestMethod]
+        public void TestEmptyCatalogue()
+        {
+            var testTrinoFunction = new TrinoFunctionTestHelper(string.Empty, "testFunc", []);
+            var statement = testTrinoFunction.GetStatement();
+
+            Assert.AreEqual("testFunc()", statement);
+        }
+
+        [TestMethod]
+        public void TestIntegralParams()
+        {
+            IList<object> args = [(sbyte)1, (byte)2, (short)3, (ushort)4, 5, 6U, 7L, 8UL, (nint)9, (nuint)10];
+            var testTrinoFunction = new TrinoFunctionTestHelper(string.Empty, "testFunc", args);
+            var statement = testTrinoFunction.GetStatement();
+
+            Assert.AreEqual("testFunc(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)", statement);
+        }
+
+        [TestMethod]
+        public void TestFractionalParams()
+        {
+            IList<object> args = [1.5f, 2.5d, 3.5m];
+            var testTrinoFunction = new TrinoFunctionTestHelper(string.Empty, "testFunc", args);
+            var statement = testTrinoFunction.GetStatement();
+
+            Assert.AreEqual("testFunc(1.5, 2.5, 3.5)", statement);
+        }
+
+        [TestMethod]
+        public void TestBooleanParams()
+        {
+            IList<object> args = [true, false];
+            var testTrinoFunction = new TrinoFunctionTestHelper(string.Empty, "testFunc", args);
+            var statement = testTrinoFunction.GetStatement();
+
+            Assert.AreEqual("testFunc(1, 0)", statement);
+        }
+
+        [TestMethod]
+        public void TestDateParams()
+        {
+            IList<object> args = [
+                new DateTime(2025, 4, 3),
+                new DateTime(2025, 4, 3, 12, 0, 0),
+                new DateTimeOffset(2025, 4, 3, 12, 0, 0, new TimeSpan(1, 0, 0))
+            ];
+            var testTrinoFunction = new TrinoFunctionTestHelper(string.Empty, "testFunc", args);
+            var statement = testTrinoFunction.GetStatement();
+
+            Assert.AreEqual("testFunc('2025-04-03T00:00:00', '2025-04-03T12:00:00', '2025-04-03T12:00:00')", statement);
+        }
+    }
+}


### PR DESCRIPTION
I wanted to do a little more than just ask questions ([here](https://github.com/trinodb/trino-csharp-client/issues/10) and [here](https://github.com/trinodb/trino-csharp-client/issues/23)) so I looked around the codebase to see if I could contribute anything. I noticed the TrinoFunction class was missing unit tests and drafted some.

In doing so I've observed that there are a handful of bugs:

1. the following integral types are quoted when passed into a function (i.e. `catalog.myfunction("1", "2.0")` rather than `catalog.myfunction(1, 2.0)`):
    - `sbyte`
    - `byte`
    - `short`
    - `ushort`
    - `uint`
    - `ulong`
    - `System.IntPtr` / `nint`
    - `System.UIntPtr` / `uint`
4. similarly `decimal` types are quoted when they shouldn't be
5. `bool` parameters are quoted as "true/false" rather than as 1/0 'bit' types (I am less certain of this one)
6. date & time parameters use a possibly ambiguous representation rather than ISO 8601 (Again I am not 100% on this one)

This PR contains the following changes:

1. a new test class `TrinoFunctionTests`, many of which (four out of nine) failed with the existing implementation of `TrinoFunction`
2. an updated version of `TrinoFunction` that causes the tests to pass. I have adjusted it slightly because the existing implementation was slightly non-idiomatic - now using `foreach (var parameter in Parameters)` rather than `for (int i = 0; i < Parameters.Count; i++)` for example.

Before you begin think about merging this could someone please just double check that my assumptions below are correct:

1. that `bool` typed params should be 1/0 rather than "true"/"false"
2. that the format of the Date, DateTime and DateTimeOffset params are correct (that they should be ISO 8601 format)
3. that we'd rather have a slightly funky test setup where I subclass `TrinoFunction` in order to access the protected `BuildFunctionStatement()` method rather than:
    - making that function public (very bad practice)
    - introducing a `IRecordExecutorFactory` interface, injecting that on instantiation and testing also `TrinoFunction.Execute` (feels a bit unnecessarily "[AbstractEnterpriseSingletonProxyFactory](https://news.ycombinator.com/item?id=4549544)")
    - abstract the function statement builder into a class (slight overengineering)
4. that my changes to TrinoFunction are generally welcome - as I said, I changed things around quite a bit!