### PR TITLE
Fix httpClient initialization in StatementClientV1 class.

### DIFF
--- a/trino-csharp/Trino.Client/StatementClientV1.cs
+++ b/trino-csharp/Trino.Client/StatementClientV1.cs
@@ -146,7 +146,7 @@ namespace Trino.Client
                 return sslPolicyErrors == SslPolicyErrors.None;
             };
 
-            HttpClient httpClient = new HttpClient(handler);
+            this.httpClient = new HttpClient(handler);
             this.httpClient.Timeout = Constants.HttpConnectionTimeout;
 
             if (!this.Session.Properties.CompressionDisabled)


### PR DESCRIPTION
Fix httpClient initialisation, assign it to a class field instead of a local variable.
It's a fix for this issue: https://github.com/trinodb/trino-csharp-client/issues/14
