### PR TITLE
fix decimal issue

### DIFF
--- a/trino-csharp/Trino.Client/Types/BigDecimal.cs
+++ b/trino-csharp/Trino.Client/Types/BigDecimal.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Numerics;
+using System.Globalization;
 
 namespace Trino.Client.Types
 {
@@ -7,28 +8,33 @@ namespace Trino.Client.Types
     {
         private BigInteger integerPart;
         private BigInteger fractionalPart;
-
-        /// <summary>
-        /// The scale represents the number of digits to the right of the decimal point.
-        /// It is used to determine the precision of the fractional part of the BigDecimal.
-        /// </summary>
-        /// <example>
-        /// For example, if the BigDecimal is "123.00456", the scale is 5 because there are five digits to the right of the decimal point, including the leading zeros.
-        /// </example>
         private int scale;
+        private int sign; // store explicit sign to preserve "-0.xxx" cases
 
         public TrinoBigDecimal(string value)
         {
+            if (string.IsNullOrWhiteSpace(value))
+                throw new ArgumentException("Invalid decimal string.");
+
+            value = value.Trim();
+
+            // Detect sign explicitly
+            sign = value.StartsWith("-", StringComparison.Ordinal) ? -1 : 1;
+            if (value.StartsWith("+") || value.StartsWith("-"))
+                value = value.Substring(1);
+
             var parts = value.Split('.');
             integerPart = BigInteger.Parse(parts[0]);
             fractionalPart = parts.Length > 1 ? BigInteger.Parse(parts[1]) : BigInteger.Zero;
             scale = parts.Length > 1 ? parts[1].Length : 0;
+
             Validate();
         }
 
         public TrinoBigDecimal(BigInteger integerPart, BigInteger fractionalPart, int scale)
         {
-            this.integerPart = integerPart;
+            sign = integerPart.Sign < 0 ? -1 : 1;
+            this.integerPart = BigInteger.Abs(integerPart);
             this.fractionalPart = fractionalPart;
             this.scale = scale;
             Validate();
@@ -37,22 +43,57 @@ namespace Trino.Client.Types
         private void Validate()
         {
             if (fractionalPart < 0)
-            {
                 throw new ArgumentException("fractionalPart cannot be negative.");
-            }
         }
 
         public override string ToString()
         {
-            return scale > 0 ? $"{integerPart}.{fractionalPart.ToString().PadLeft(scale, '0')}" : integerPart.ToString();
+            string core = scale > 0
+                ? $"{integerPart}.{fractionalPart.ToString().PadLeft(scale, '0')}"
+                : integerPart.ToString();
+            return sign < 0 ? "-" + core : core;
         }
+
+        public decimal ToDecimal()
+        {
+            const int maxPrecisionForDecimal = 28;
+
+            BigInteger total = integerPart * BigInteger.Pow(10, scale) + fractionalPart;
+            decimal result = (decimal)total / (decimal)BigInteger.Pow(10, scale);
+
+            if (sign < 0)
+                result = -result;
+
+            // Validate precision
+            int digits = integerPart.IsZero ? 0 : (int)Math.Floor(BigInteger.Log10(integerPart)) + 1;
+            if (scale + digits > maxPrecisionForDecimal)
+                throw new OverflowException("The precision exceeds the allowable limit for a decimal.");
+
+            return result;
+        }
+
+        public int GetScale() => scale;
+
+        public int GetPrecision()
+        {
+            var integerDigits = integerPart.IsZero ? 0 : (int)Math.Floor(BigInteger.Log10(integerPart)) + 1;
+            return integerDigits + scale;
+        }
+
+        public int GetSign() => sign;
+
+        public BigInteger GetIntegerPart() => integerPart * sign;
+
+        public BigInteger GetFractionalPart() => fractionalPart;
 
         public override bool Equals(object obj)
         {
             if (obj is TrinoBigDecimal other)
             {
                 AlignScales(ref this, ref other);
-                return integerPart == other.integerPart && fractionalPart == other.fractionalPart;
+                return sign == other.sign &&
+                       integerPart == other.integerPart &&
+                       fractionalPart == other.fractionalPart;
             }
             return false;
         }
@@ -65,57 +106,11 @@ namespace Trino.Client.Types
                 hash = hash * 31 + integerPart.GetHashCode();
                 hash = hash * 31 + fractionalPart.GetHashCode();
                 hash = hash * 31 + scale.GetHashCode();
+                hash = hash * 31 + sign.GetHashCode();
                 return hash;
             }
         }
 
-        /// <summary>
-        /// Converts to a decimal, throws overflow exception.
-        /// </summary>
-        public decimal ToDecimal()
-        {
-            const int maxPrecisionForDecimal = 28; // 29 is limit in some circumstances
-            int digits = integerPart.IsZero ? 0 : (int)Math.Floor(BigInteger.Log10(integerPart)) + 1;
-            if (scale + digits > maxPrecisionForDecimal)
-            {
-                throw new OverflowException("The precision exceeds the allowable limit for a decimal.");
-            }
-
-            // Check if integerPart is within the range of decimal
-            if (integerPart < (BigInteger)decimal.MinValue || integerPart > (BigInteger)decimal.MaxValue)
-            {
-                throw new OverflowException("The integer part is out of range for a decimal.");
-            }
-
-            var integerDecimal = (decimal)integerPart;
-
-            // Check if fractionalPart is within the range of decimal
-            var fractionalDecimal = (decimal)fractionalPart / (decimal)BigInteger.Pow(10, scale);
-            if (fractionalDecimal < decimal.MinValue || fractionalDecimal > decimal.MaxValue)
-            {
-                throw new OverflowException("The fractional part is out of range for a decimal.");
-            }
-
-            // This will throw an overflow exception
-            return integerDecimal + fractionalDecimal;
-        }
-
-        public int GetScale() => scale;
-        public int GetPrecision()
-        {
-            var integerDigits = integerPart.IsZero ? 0 : (int)Math.Floor(BigInteger.Log10(integerPart)) + 1;
-            return integerDigits + scale;
-        }
-        public int GetSign() => integerPart.Sign;
-        public BigInteger GetIntegerPart() => integerPart;
-        public BigInteger GetFractionalPart() => fractionalPart;
-
-        /// <summary>
-        /// The AlignScales method ensures that two BigDecimal instances have the same scale before performing arithmetic operations.
-        /// a = 1.23 (scale = 2)
-        /// b = 4.567 (scale = 3)
-        /// a's fractional part is adjusted to 230 (by multiplying by 10) to match the scale of 3.
-        /// </summary>
         private static void AlignScales(ref TrinoBigDecimal a, ref TrinoBigDecimal b)
         {
             if (a.scale > b.scale)

--- a/trino-csharp/Trino.Client/Types/BigDecimal.cs
+++ b/trino-csharp/Trino.Client/Types/BigDecimal.cs
@@ -8,6 +8,14 @@ namespace Trino.Client.Types
     {
         private BigInteger integerPart;
         private BigInteger fractionalPart;
+
+        /// <summary>
+        /// The scale represents the number of digits to the right of the decimal point.
+        /// It is used to determine the precision of the fractional part of the BigDecimal.
+        /// </summary>
+        /// <example>
+        /// For example, if the BigDecimal is "123.00456", the scale is 5 because there are five digits to the right of the decimal point, including the leading zeros.
+        /// </example>
         private int scale;
         private int sign; // store explicit sign to preserve "-0.xxx" cases
 
@@ -33,7 +41,7 @@ namespace Trino.Client.Types
 
         public TrinoBigDecimal(BigInteger integerPart, BigInteger fractionalPart, int scale)
         {
-            sign = integerPart.Sign < 0 ? -1 : 1;
+            this.sign = integerPart.Sign < 0 ? -1 : 1;
             this.integerPart = BigInteger.Abs(integerPart);
             this.fractionalPart = fractionalPart;
             this.scale = scale;
@@ -111,6 +119,12 @@ namespace Trino.Client.Types
             }
         }
 
+        /// <summary>
+        /// The AlignScales method ensures that two BigDecimal instances have the same scale before performing arithmetic operations.
+        /// a = 1.23 (scale = 2)
+        /// b = 4.567 (scale = 3)
+        /// a's fractional part is adjusted to 230 (by multiplying by 10) to match the scale of 3.
+        /// </summary>
         private static void AlignScales(ref TrinoBigDecimal a, ref TrinoBigDecimal b)
         {
             if (a.scale > b.scale)


### PR DESCRIPTION
## Summary by Sourcery

Preserve explicit sign in TrinoBigDecimal to correctly handle negative zero and improve decimal parsing, string conversion, equality, hashing, and conversion to decimal.

New Features:
- Store an explicit sign field to distinguish negative zero cases
- Add GetScale, GetPrecision, GetSign, GetIntegerPart, and GetFractionalPart accessors

Bug Fixes:
- Fix ToString, Equals, and GetHashCode to account for the explicit sign

Enhancements:
- Uniformly parse and apply sign in both string and BigInteger constructors
- Unify and simplify ToDecimal implementation with precision validation